### PR TITLE
Feature/incremental build support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,11 @@ FROM usdotfhwastoldev/carma-base:develop as deps
 
 FROM deps as setup
 
+ARG ROS1_PACKAGES=""
+ENV ROS1_PACKAGES=${ROS1_PACKAGES}
+ARG ROS2_PACKAGES=""
+ENV ROS2_PACKAGES=${ROS2_PACKAGES}
+
 RUN mkdir ~/src
 COPY --chown=carma . /home/carma/src/
 RUN ~/src/docker/checkout.bash

--- a/docker/build-image.sh
+++ b/docker/build-image.sh
@@ -17,7 +17,7 @@
 USERNAME=usdotfhwastol
 
 cd "$(dirname "$0")"
-IMAGE=carma-novatel-gps-driver
+IMAGE=$(basename `git rev-parse --show-toplevel`)
 
 echo ""
 echo "##### $IMAGE Docker Image Build Script #####"
@@ -44,8 +44,58 @@ while [[ $# -gt 0 ]]; do
             COMPONENT_VERSION_STRING=develop
             shift
             ;;
+        --ros-1-packages|--ros1)
+            ROS1_PACKAGES=""
+            shift
+            ;;
+        --ros-2-packages|--ros2)
+            ROS2_PACKAGES=""
+            shift
+            ;;
+        *)
+            # Var test based on Stack Overflow question: https://stackoverflow.com/questions/5406858/difference-between-unset-and-empty-variables-in-bash
+            # Asker: green69
+            # Answerer: geekosaur
+            if [ "${ROS2_PACKAGES+set}" = "set" ]; then
+                ROS2_PACKAGES="$ROS2_PACKAGES $arg"
+            elif [ "${ROS1_PACKAGES+set}" = "set" ]; then
+                ROS1_PACKAGES="$ROS1_PACKAGES $arg"
+            else
+                echo "Unknown argument $arg..."
+                exit -1
+            fi 
+            shift
+            ;;
     esac
 done
+
+if [[ ! -z "$ROS1_PACKAGES$ROS2_PACKAGES" ]]; then
+    echo "Performing incremental build of image to rebuild packages: $ROS1_PACKAGES $ROS2_PACKAGES..."
+
+    echo "Updating Dockerfile references to use most recent image as base image"
+    # Trim of docker image LS command sourced from 
+    # https://stackoverflow.com/questions/50625619/why-doesnt-the-cut-command-work-for-a-docker-image-ls-command
+    # Question Asker: Chris F
+    # Question Answerer: Arount
+    MOST_RECENT_IMAGE_DATA=$(docker image ls | grep $IMAGE | tr -s ' ')
+
+    if [[ -z "$MOST_RECENT_IMAGE_DATA" ]]; then
+        echo No prior image exists to use as base, an initial image must be built first before attempting incremental build.
+        exit -1
+    fi
+
+    MOST_RECENT_IMAGE_HASH=$(echo $MOST_RECENT_IMAGE_DATA | cut -d " " -f 3)
+    MOST_RECENT_IMAGE_ORG=$(echo $MOST_RECENT_IMAGE_DATA | cut -d " " -f 1 | cut -d "/" -f 1)
+    MOST_RECENT_IMAGE_TAG=$(echo $MOST_RECENT_IMAGE_DATA | cut -d " " -f 2)
+    MOST_RECENT_IMAGE_DATE=$(echo $MOST_RECENT_IMAGE_DATA | cut -d " " -f 4,5,6)
+
+    echo Using $MOST_RECENT_IMAGE_TAG $MOST_RECENT_IMAGE_HASH $MOST_RECENT_IMAGE_DATE as base for partial build...
+
+    sed -i "s|^FROM[[:space:]]*[^[:space:]]*|FROM $MOST_RECENT_IMAGE_HASH|I" ../Dockerfile
+
+    COMPONENT_VERSION_STRING="SNAPSHOT"
+    USERNAME="local"
+fi
 
 if [[ -z "$COMPONENT_VERSION_STRING" ]]; then
     COMPONENT_VERSION_STRING=$("./get-component-version.sh")
@@ -61,8 +111,18 @@ if [[ $COMPONENT_VERSION_STRING = "develop" ]]; then
         --build-arg VERSION="$COMPONENT_VERSION_STRING" \
         --build-arg VCS_REF=`git rev-parse --short HEAD` \
         --build-arg BUILD_DATE=`date -u +”%Y-%m-%dT%H:%M:%SZ”` .
+elif [[ $COMPONENT_VERSION_STRING = "SNAPSHOT" ]]; then
+    docker build --network=host --no-cache -t $USERNAME/$IMAGE:$COMPONENT_VERSION_STRING \
+        --build-arg ROS1_PACKAGES="$ROS1_PACKAGES" \
+        --build-arg ROS2_PACKAGES="$ROS2_PACKAGES" \
+        --build-arg VERSION="$COMPONENT_VERSION_STRING" \
+        --build-arg VCS_REF=`git rev-parse --short HEAD` \
+        --build-arg BUILD_DATE=`date -u +”%Y-%m-%dT%H:%M:%SZ”` .
 else
-    docker build --no-cache -t $USERNAME/$IMAGE:$COMPONENT_VERSION_STRING \
+    #The addition of --network=host was a fix for a DNS resolution error that occured 
+    #when running the platform inside an Ubuntu 20.04 virtual machine. The error and possible soliutions are 
+    # discussed here: https://github.com/moby/moby/issues/41003
+    docker build --network=host --no-cache -t $USERNAME/$IMAGE:$COMPONENT_VERSION_STRING \
         --build-arg VERSION="$COMPONENT_VERSION_STRING" \
         --build-arg VCS_REF=`git rev-parse --short HEAD` \
         --build-arg BUILD_DATE=`date -u +”%Y-%m-%dT%H:%M:%SZ”` .

--- a/docker/install.sh
+++ b/docker/install.sh
@@ -15,6 +15,17 @@
 #  the License.
 
 sudo chmod -R +x /opt/carma/install
-source /opt/ros/noetic/setup.bash
+if [[ ! -z "$ROS1_PACKAGES" ]]; then
+    echo "Sourcing previous build for incremental build start point..."
+    source /opt/carma/install/setup.bash
+else
+    echo "Sourcing base image for full build..."
+    source /opt/ros/noetic/setup.bash
+fi
+
 cd ~/
-colcon build --cmake-args -DCMAKE_BUILD_TYPE=Release
+if [[ ! -z "$ROS1_PACKAGES" ]]; then
+    colcon build --cmake-args -DCMAKE_BUILD_TYPE=Release --packages-above $ROS1_PACKAGES
+else
+    colcon build --cmake-args -DCMAKE_BUILD_TYPE=Release
+fi


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

Updates the build scripts to support incremental builds using the --ros1 and --ros2 flags. Also standardizes script names and structures where needed to match with release-tool.sh expectations.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
This change will significantly cut down on time needed for development builds where on specific packages have changed. By specifying the changed packages using the aforementioned flags, only the specified packages will be rebuilt and all other packages will be referenced from the previous build of the image.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Varying types of build configurations (ros1 and ros2, ros1 only, ros2 only) have been tested and confirmed to build succesfully.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.